### PR TITLE
Update sensor code with speed and filespace improvements.

### DIFF
--- a/accelerometer/sensor_logger.ino
+++ b/accelerometer/sensor_logger.ino
@@ -169,17 +169,17 @@ void loop() {
   dataFile.print(stop_us - start_us);
   dataFile.print(',');
   
-  DEBUG_PRINT(lis.x);
+  DEBUG_PRINT(lis.x_g);
   DEBUG_PRINT(',');
-  DEBUG_PRINT(lis.y);
+  DEBUG_PRINT(lis.y_g);
   DEBUG_PRINT(',');
-  DEBUG_PRINT(lis.z);
+  DEBUG_PRINT(lis.z_g);
   // Write acceleration to file.
-  dataFile.print(lis.x);
+  dataFile.print(lis.x_g);
   dataFile.print(',');
-  dataFile.print(lis.y);
+  dataFile.print(lis.y_g);
   dataFile.print(',');
-  dataFile.print(lis.z);
+  dataFile.print(lis.z_g);
 
   DEBUG_PRINTLN();
   // Write newline.

--- a/accelerometer/sensor_logger.ino
+++ b/accelerometer/sensor_logger.ino
@@ -1,26 +1,24 @@
 /**
  * Created by Ammolytics
  * License: MIT
- * Version: 1.0.0
+ * Version: 2.0.0
  * URL: https://github.com/ammolytics/projects/
  * Inexpensive firearm accelerometer based on the Adafruit LIS3DH breakout board.
  */
 
 #include <Wire.h>
 #include <SPI.h>
-#include <SD.h>
 #include <Adafruit_LIS3DH.h>
 #include <Adafruit_Sensor.h>
 #include "RTClib.h"
+#include "SdFat.h"
 
-// Used for software SPI
-#define LIS3DH_CLK 13
-#define LIS3DH_MISO 12
-#define LIS3DH_MOSI 11
-// Used for hardware & software SPI
-#define LIS3DH_CS 10
 
+// Battery pin
 #define VBATPIN A7
+
+// I2C clock speed
+#define I2C_SPEED 1000000
 
 // Enable debug logger.
 // Note: Comment out before running in real-world.
@@ -39,19 +37,18 @@ RTC_PCF8523 rtc;
 // change this to match your SD shield or module;
 // Adafruit SD shields and modules: pin 10
 const int chipSelect = 10;
-// 19 digits plus the null char
-char DateTimeString[20];
 
-// Filename format:  20180710.csv
-char filename[13];
 
-char dataRow[10000];
-String strRow;
-int counter = 0;
+// Filename format:  YYYYMMDDHHmm.csv
+char filename[17];
 
-int lastX;
 
-File dataFile;
+unsigned long begin_us;
+unsigned long begin_epoch;
+unsigned long start_us;
+unsigned long stop_us;
+unsigned long counter = 0;
+
 
 // software SPI
 //Adafruit_LIS3DH lis = Adafruit_LIS3DH(LIS3DH_CS, LIS3DH_MOSI, LIS3DH_MISO, LIS3DH_CLK);
@@ -60,29 +57,33 @@ File dataFile;
 // I2C
 Adafruit_LIS3DH lis = Adafruit_LIS3DH();
 
+// global event
+sensors_event_t event;
+
+// set up variables using the SD utility library functions:
+// File system object.
+SdFat sd;
+// Log file.
+SdFile dataFile;
+
 
 void setup() {
   #ifdef DEBUG
-    Serial.begin(9600);
+    Serial.begin(115200);
     while (!Serial);     // will pause Zero, Leonardo, etc until serial console opens
   #endif
 
-  float measuredvbat = analogRead(VBATPIN);
-  measuredvbat *= 2;    // we divided by 2, so multiply back
-  measuredvbat *= 3.3;  // Multiply by 3.3V, our reference voltage
-  measuredvbat /= 1024; // convert to voltage
-  DEBUG_PRINT("VBat: " ); DEBUG_PRINTLN(measuredvbat);
+  #ifdef DEBUG
+    float measuredvbat = analogRead(VBATPIN);
+    measuredvbat *= 2;    // we divided by 2, so multiply back
+    measuredvbat *= 3.3;  // Multiply by 3.3V, our reference voltage
+    measuredvbat /= 1024; // convert to voltage
+    DEBUG_PRINT("VBat: " ); DEBUG_PRINTLN(measuredvbat);
+  #endif
 
-  DEBUG_PRINTLN("Initializing SD card...");
-
-  if (!SD.begin(chipSelect)) {
-    DEBUG_PRINTLN("Card failed, or not present");
-    // don't do anything more:
-    while (1);
-  }
-  DEBUG_PRINTLN("Card initialized.");
-
-  
+  /**
+   * Initialize the Real Time Clock.
+   */
   DEBUG_PRINTLN("Initializing RTC...");
   if (! rtc.begin()) {
     DEBUG_PRINTLN("Couldn't find RTC");
@@ -92,19 +93,59 @@ void setup() {
     DEBUG_PRINTLN("RTC is NOT running!");
   }
   DEBUG_PRINTLN("RTC initialized.");
+  begin_us = micros();
+  DateTime now = rtc.now();
+  begin_epoch = now.unixtime();
 
+  /**
+   * Initialize the SD card and log file.
+   */
+  DEBUG_PRINTLN("Initializing SD card...");
+  if (!sd.begin(chipSelect, SD_SCK_MHZ(50))) {
+    DEBUG_PRINTLN("Card failed, or not present");
+    // don't do anything more:
+    while (1);
+  }
+  DEBUG_PRINTLN("Card initialized.");
   
+  sprintf_P(filename, PSTR("%4d%02d%02d%02d%02d.csv"), now.year(), now.month(), now.day(), now.hour(), now.minute());
+  DEBUG_PRINT("Filename: ");
+  DEBUG_PRINTLN(filename);
+
+  if (! dataFile.open(filename, O_CREAT | O_APPEND | O_WRITE)) {
+     DEBUG_PRINTLN("Could not open file...");
+     while (1);
+  }
+  DEBUG_PRINTLN("timestamp (s), start (µs), delta (µs), accel x (m/s²), accel y (m/s²), accel z (m/s²)");
+  dataFile.println("timestamp (s), start (µs), delta (µs), accel x (m/s²), accel y (m/s²), accel z (m/s²)");
+  dataFile.flush();
+  
+  // Check to see if the file exists:
+  if (! sd.exists(filename)) {
+    DEBUG_PRINTLN("Log file doesn't exist.");
+    while (1);
+  }
+  
+  /**
+   * Initialize the accelerometer.
+   */
   DEBUG_PRINTLN("Initializing LIS3DH Sensor...");
-  if (! lis.begin(0x18)) {   // change this to 0x19 for alternative i2c address
+  if (! lis.begin(LIS3DH_DEFAULT_ADDRESS)) {   // change this to 0x19 for alternative i2c address
     DEBUG_PRINTLN("Couldnt start");
     while (1);
   }
-  lis.setRange(LIS3DH_RANGE_4_G);   // 2, 4, 8 or 16 G!
+  // Set I2C high speedmode
+  Wire.setClock(I2C_SPEED);
+  // Set range to 8G
+  lis.setRange(LIS3DH_RANGE_8_G);
+  // 5khz data rate
+  lis.setDataRate(LIS3DH_DATARATE_LOWPOWER_5KHZ);
   DEBUG_PRINTLN("LIS3DH initialized.");
 
 
   DEBUG_PRINTLN("Ready!");
 
+  /**
   DateTime now = rtc.now();
   sprintf_P(DateTimeString, PSTR("%4d-%02d-%02d %d:%02d:%02d"),
       now.year(), now.month(), now.day(), now.hour(), now.minute(), now.second());
@@ -112,107 +153,61 @@ void setup() {
 
   DEBUG_PRINTLN(DateTimeString);
   DEBUG_PRINTLN(filename);
-
-  dataFile = SD.open(filename, O_CREAT | O_WRITE);
-  dataFile.println("timestamp, accel x, accel y, accel z, accel unit, sensor range, millis, micros, voltage");
-  DEBUG_PRINTLN(dataFile);
-  if (! dataFile) {
-     DEBUG_PRINTLN("Could not open file...");
-  }
-  dataFile.close();
-
-  // Check to see if the file exists:
-  if (SD.exists(filename)) {
-    DEBUG_PRINTLN("Log file exists.");
-  } else {
-    DEBUG_PRINTLN("Log file doesn't exist.");
-  }
-
-  // Leave the file open for writing.
-  dataFile = SD.open(filename, O_CREAT | O_APPEND | O_WRITE);
+  */
 }
 
 
 
 // Main Loop
 void loop() {
-  float measuredvbat = analogRead(VBATPIN);
-  measuredvbat *= 2;    // we divided by 2, so multiply back
-  measuredvbat *= 3.3;  // Multiply by 3.3V, our reference voltage
-  measuredvbat /= 1024; // convert to voltage
-  //DEBUG_PRINT("VBat: " ); DEBUG_PRINTLN(measuredvbat);
-  
-  lis.read();      // get X Y and Z data at once
-  // Then print out the raw data
-  /*
-  DEBUG_PRINT(lis.x); DEBUG_PRINT(", ");
-  DEBUG_PRINT(lis.y); DEBUG_PRINT(", ");
-  DEBUG_PRINT(lis.z); DEBUG_PRINT(", ");
-  */
-
-  /* Or....get a new sensor event, normalized */ 
-  sensors_event_t event;
+  start_us = micros();
   lis.getEvent(&event);
+  stop_us = micros();
 
-  int rangeVal = 2 << lis.getRange();
+  // Roughly equivalent to calling rtc.now().unixtime(), without 1ms latency.
+  DEBUG_PRINT(begin_epoch + ((stop_us - begin_us) / 1000000));
+  DEBUG_PRINT(',');
+  // repeat
+  dataFile.print(begin_epoch + ((stop_us - begin_us) / 1000000));
+  dataFile.print(',');
 
-  DateTime now = rtc.now();
-
-  /*
-  sprintf_P(dataRow, PSTR("%d, %d, %d, %d, %s, %s, %d"), 
-      now.unixtime(), event.acceleration.x, event.acceleration.y, event.acceleration.z, "m/s^2", rangeVal, millis());
-
-  DEBUG_PRINTLN(dataRow);
-  */
+  DEBUG_PRINT(start_us);
+  DEBUG_PRINT(',');
+  DEBUG_PRINT(stop_us - start_us);
+  DEBUG_PRINT(',');
+  // repeat
+  dataFile.print(start_us);
+  dataFile.print(',');
+  dataFile.print(stop_us - start_us);
+  dataFile.print(',');
   
-  /* Display the results (acceleration is measured in m/s^2) */
-  strRow = String(now.unixtime()) + ", ";
-  strRow += String(event.acceleration.x) + ", ";
-  strRow += String(event.acceleration.y) + ", ";
-  strRow += String(event.acceleration.z) + ", ";
-  strRow += "m/s^2, ";
-  strRow += String(rangeVal) + ", ";
-  strRow += String(millis()) + ", ";
-  strRow += String(micros()) + ", ";
-  strRow += String(measuredvbat);
+  DEBUG_PRINT(event.acceleration.x);
+  DEBUG_PRINT(',');
+  DEBUG_PRINT(event.acceleration.y);
+  DEBUG_PRINT(',');
+  DEBUG_PRINT(event.acceleration.z);
+  // repeat
+  dataFile.print(event.acceleration.x);
+  dataFile.print(',');
+  dataFile.print(event.acceleration.y);
+  dataFile.print(',');
+  dataFile.print(event.acceleration.z);
   
-  DEBUG_PRINTLN(strRow);  
 
-  // Open the file if it's closed.
-  if (!dataFile) {
-    dataFile = SD.open(filename, O_CREAT | O_APPEND | O_WRITE);
-  }
-  // if the file is available, write to it:
-  if (dataFile) {
-    dataFile.println(strRow);
-  } else {
-    // if the file isn't open, pop up an error:
-    DEBUG_PRINTLN("error opening file");
-  }
-
-  // Determine if the unit is actively recording important motion to prevent delays from writing ops.
-  // X-Axis is inline with bore. Least likely to detect acceleration of gravity.
-  bool inMotion = false;
-  if (max(event.acceleration.x, lastX) > 1.0 || min(event.acceleration.x, lastX) < -1.0) {
-    inMotion = true;
-  }
-
+  DEBUG_PRINTLN();
+  dataFile.println();
   counter++;
-  // write the data to prevent loss.
-  if (counter >= 20 && !inMotion) {
-    DEBUG_PRINTLN("Data file write/flush.");
-    dataFile.flush();
-    counter = 0;
-  } else {
-    DEBUG_PRINTLN(inMotion);
-  }
-  if (counter >= 100) {
-    DEBUG_PRINTLN("Data file write/close.");
-    dataFile.close();
-    counter = 0;
-  }
 
-  lastX = event.acceleration.x;
- 
-  //delay(1);
+
+  /**
+   * This can take between 9 and 26 milliseconds. Or ~10ms with SDfat.
+   */
+  if (counter >= 800) {
+    DEBUG_PRINTLN("Writing to SD card");
+    unsigned long pre_write = micros();
+    dataFile.flush();
+    unsigned long post_write = micros();
+    DEBUG_PRINT("Write ops took: "); DEBUG_PRINTLN(post_write - pre_write);
+    counter = 0;
+  }
 }


### PR DESCRIPTION
Taking the advice offered in #1 , this updated version runs around **6x faster** than before and trims down the output file.

### Changes:
- Changed accelerometer from 4G to 8G range.
- Changed acceleration output from `m/s²` to `G` since it's metric/imperial agnostic.
- Called `lis.read()` directly instead of `lis.getEvent()` for a very small speed boost (but mostly to avoid conversion from `G` to `m/s²`.
- Set accelerometer to faster data rate (unsure this has an effect [due to issues in the library](https://github.com/adafruit/Adafruit_LIS3DH/issues/14)).
- Use [SDFat library](https://github.com/greiman/SdFat) to support long filenames.
- Uses a full timestamp for the output filename (e.g. `201902171830.csv`).
- Set I2C speed to [fast mode](https://www.i2c-bus.org/fastmode/).
- Define the column units (e.g. `µs`, `G`) in the header row to reduce disk usage.
- Dropped `millis()` from output (same info provided by `micros()`).
- Dropped battery voltage from output.
- Dropped acceleration range from output (inconsequential).
- Use `unsigned long` variables to reduce overhead.
- Call the `unixtime()` just once at start up and use `micros()` to estimate time afterward (shaved off 30ms per loop).
 - Dropped the motion-detection aspect of data writing and simply write the data to the SD card every 800 loops.

**Note:** The process of writing to disk takes around 10 ms, which is still fairly slow. Ideally a buffered approach which only recorded movement would keep the output file significantly smaller. I hope to add that in a future iteration.

### Chart Preview

![Acceleration Chart](https://user-images.githubusercontent.com/507145/51434475-d2eab980-1c15-11e9-9045-1cf84aec0b19.png)

### Output Data Format

Here's a quick comparison of what the output data looks like before and after this change.

#### Before

|timestamp | accel x | accel y | accel z | accel unit | sensor range | millis | micros | voltage |
| -- | -- | -- | -- | -- | -- | -- | -- | -- |
| 1535376330 | 1.59 | 9.96 | -1.53 | m/s^2 | 4 | 128808 | 128808823 | 4.15 |
| 1535376330 | 2.26 | 11.90 | -2.95 | m/s^2 | 4 | 128817 | 128817310 | 4.14 |
| 1535376330 | 2.68 | 10.86 | -2.09 | m/s^2 | 4 | 128823 | 128823514 | 4.14 |
| 1535376330 | 2.39 | 9.46 | -1.21 | m/s^2 | 4 | 128829 | 128829672 | 4.15 |
| 1535376330 | 1.88 | 8.47 | -1.23 | m/s^2 | 4 | 128835 | 128835808 | 4.14 |
| 1535376330 | 1.28 | 7.68 | -1.42 | m/s^2 | 4 | 128841 | 128841962 | 4.14 |

#### After

| timestamp (s) | start (µs) | delta (µs) | accel x (G) | accel y (G) | accel z (G) |
| -- | -- | -- | -- | -- | -- |
| 1547749706 | 123593 | 223 | 0.75 | 1.19 | -0.19 |
| 1547749706 | 125917 | 251 | 0.80 | 1.19 | -0.22 |
| 1547749706 | 126979 | 252 | 0.85 | 1.11 | -0.21 |
| 1547749706 | 128040 | 252 | 0.85 | 1.09 | -0.26 |
| 1547749706 | 129097 | 251 | 0.94 | 1.05 | -0.22 |
| 1547749706 | 130158 | 252 | 0.97 | 1.02 | -0.20 |